### PR TITLE
Don't delete system catalog tables in Postgres

### DIFF
--- a/prom/interface/base.py
+++ b/prom/interface/base.py
@@ -582,7 +582,8 @@ class SQLInterface(Interface):
         with self.transaction(**kwargs) as connection:
             kwargs['connection'] = connection
             for table_name in self.get_tables(**kwargs):
-                self._delete_table(table_name, **kwargs)
+                if not table_name.startswith("pg_"):
+                    self._delete_table(table_name, **kwargs)
 
         return True
 


### PR DESCRIPTION
* See diff
* We've been bumping into this recently - I'm sure there is a cleaner way to check for system catalog tables, but I couldn't figure it out.